### PR TITLE
Add admin user listing API and page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment variables
+.env

--- a/api/admin-users/list.js
+++ b/api/admin-users/list.js
@@ -1,0 +1,23 @@
+/* eslint-env node */
+import process from "node:process";
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = 'https://kmvxpnxyuzmupynnhlvl.supabase.co';
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+export default async function handler(req, res) {
+  if (req.method && req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const { data, error } = await supabase.auth.admin.listUsers();
+
+  if (error) {
+    res.status(500).json({ error: error.message });
+    return;
+  }
+
+  res.status(200).json({ users: data.users });
+}

--- a/src/pages/AdminUserManagerPage.jsx
+++ b/src/pages/AdminUserManagerPage.jsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import Header from '../components/Header';
+
+export default function AdminUserManagerPage() {
+  const [users, setUsers] = useState([]);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetch('/api/admin-users/list')
+      .then((res) => {
+        if (!res.ok) throw new Error('Failed to fetch users');
+        return res.json();
+      })
+      .then((data) => {
+        setUsers(data.users || []);
+      })
+      .catch((err) => {
+        setError(err.message);
+      });
+  }, []);
+
+  return (
+    <>
+      <Header />
+      <div>
+        <h1>Admin Users</h1>
+        {error && <p>Error: {error}</p>}
+        <ul>
+          {users.map((u) => (
+            <li key={u.id}>{u.email}</li>
+          ))}
+        </ul>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add server-side API route for listing Supabase users
- display users via AdminUserManagerPage fetching from new API
- ignore `.env` files so service role key stays server-side

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_689500fdf76c83308913cb060f811a40